### PR TITLE
Make timezone configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Prometheus exporter for SendGrid daily metrics exposed by SendGrid Stats API(v3)
 
 ```
 $ make
-$ ./exporter --sendgrid.api-key='secret' --web.listen-address=':9154' --web.disable-exporter-metrics
+$ ./dist/exporter --sendgrid.api-key='secret' --web.listen-address=':9154' --web.disable-exporter-metrics
 ```
 
 ```
@@ -31,6 +31,8 @@ Flags:
       --sendgrid.api-key="secret"
                               [Required] Set SendGrid API key
       --sendgrid.username=""  [Optional] Set SendGrid username as a label for each metrics. This is for identifying multiple SendGrid users metrics.
+      --sendgrid.location=""    [Optional] Set a zone name.(e.g. 'Asia/Tokyo') The default is UTC.
+      --sendgrid.time-offset=0  [Optional] Specify the offset in second from UTC as an integer.(e.g. '32400') This needs to be set along with location.
       --log.level=info        Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt     Output format of log messages. One of: [logfmt, json]
       --version               Show application version.

--- a/charts/Chart.yaml
+++ b/charts/Chart.yaml
@@ -3,4 +3,4 @@ name: sendgrid-stats-exporter
 description: A Helm chart for chatwork/sendgrid-stats-exporter
 type: application
 version: 0.0.1
-appVersion: 0.0.3
+appVersion: 0.0.7

--- a/charts/README.md
+++ b/charts/README.md
@@ -39,6 +39,7 @@ The following table lists the configurable parameters of the Sendgrid-stats-expo
 | `podSecurityContext` | Security context for the pod | `{}` |
 | `securityContext` | Security context for container | `{}` |
 | `envFrom` | Extra custom environment variables from ConfigMaps | `[]` |
+| `extraEnv` | Pod extra environment value | `[]`|
 | `secret.apiKey` | SendGrid api token | `{}` |
 | `secret.username` | SendGrid username | `[]` |
 | `service.type` | Service Type | `"ClusterIP"` |

--- a/charts/templates/_helpers.tpl
+++ b/charts/templates/_helpers.tpl
@@ -65,9 +65,5 @@ Create the name of the service account to use
 Return secret name to be used based on provided values.
 */}}
 {{- define "sendgrid-stats-exporter.secretName" -}}
-{{- if not .Values.secret.existingSecretName -}}
 {{ default (printf "%s-secret" (include "sendgrid-stats-exporter.fullname" . )) }}
-{{- else -}}
-    {{ .Values.secret.existingSecretName }}
-{{- end -}}
 {{- end -}}

--- a/charts/templates/deployment.yaml
+++ b/charts/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "sendgrid-stats-exporter.secretName" . }}
                   key: apiKey
+            {{- with .Values.extraEnv }}{{ toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 9154

--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 image:
   repository: chatwork/sendgrid-stats-exporter
   pullPolicy: IfNotPresent
-  tag: "0.0.3"
+  tag: "0.0.7"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -28,9 +28,9 @@ securityContext: {}
   # runAsUser: 1000
 
 envFrom: []
+extraEnv: []
 
 secret:
-  existingSecretName:
   username: ""
   apiKey: ""
 

--- a/collect.go
+++ b/collect.go
@@ -133,7 +133,14 @@ func collector(logger log.Logger) *Collector {
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	today := time.Now()
+	var today time.Time
+
+	if *location != "" && *timeOffset != 0 {
+		loc := time.FixedZone(*location, *timeOffset)
+		today = time.Now().In(loc)
+	} else {
+		today = time.Now()
+	}
 
 	statistics, err := collectByDate(today)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ var (
 	timeOffset = kingpin.Flag(
 		"sendgrid.time-offset",
 		"[Optional] Specify the offset in second from UTC as an integer.(e.g. '32400') This needs to be set along with location.",
-	).Default("0").Int()
+	).Default("0").Envar("SENDGRID_TIME_OFFSET").Int()
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -44,6 +44,14 @@ var (
 		"sendgrid.username",
 		"[Optional] Set SendGrid username as a label for each metrics. This is for identifying multiple SendGrid users metrics.",
 	).Default("").Envar("SENDGRID_USER_NAME").String()
+	location = kingpin.Flag(
+		"sendgrid.location",
+		"[Optional] Set a zone name.(e.g. 'Asia/Tokyo') The default is UTC.",
+	).Default("").Envar("SENDGRID_LOCATION").String()
+	timeOffset = kingpin.Flag(
+		"sendgrid.time-offset",
+		"[Optional] Specify the offset in second from UTC as an integer.(e.g. '32400') This needs to be set along with location.",
+	).Default("0").Int()
 )
 
 func main() {


### PR DESCRIPTION
https://sendgrid.com/docs/ui/account-and-settings/account/
> The timezone in which your company operates. This setting will be used by other SendGrid functionality such as Statistics and scheduling sends in Marketing Campaigns. Please make sure that your timezone is set to the same as your business.