### PR TITLE
Add sendgrid.accumulated-metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Flags:
       --sendgrid.username=""  [Optional] Set SendGrid username as a label for each metrics. This is for identifying multiple SendGrid users metrics.
       --sendgrid.location=""    [Optional] Set a zone name.(e.g. 'Asia/Tokyo') The default is UTC.
       --sendgrid.time-offset=0  [Optional] Specify the offset in second from UTC as an integer.(e.g. '32400') This needs to be set along with location.
+      --sendgrid.accumulated-metrics=False [Optional] Accumulated SendGrid Metrics by month, to calculate monthly email limit.
       --log.level=info        Only log messages with the given severity or above. One of: [debug, info, warn, error]
       --log.format=logfmt     Output format of log messages. One of: [logfmt, json]
       --version               Show application version.
@@ -69,7 +70,7 @@ unsubscribes | The number of recipients who unsubscribed from your emails.
 ```
 $ docker run -d -p 9154:9154 chatwork/sendgrid-stats-exporter
 ```
- 
+
 #### Running with `docker-compose`
 
 ```

--- a/collect.go
+++ b/collect.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/jinzhu/now"
 )
 
 type Collector struct {
@@ -142,7 +143,12 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		today = time.Now()
 	}
 
-	statistics, err := collectByDate(today)
+	queryDate := today
+	if *accumulatedMetrics {
+		queryDate = now.With(today).BeginningOfMonth()
+	}
+
+	statistics, err := collectByDate(queryDate, today)
 	if err != nil {
 		level.Error(c.logger).Log(err)
 

--- a/main.go
+++ b/main.go
@@ -52,6 +52,11 @@ var (
 		"sendgrid.time-offset",
 		"[Optional] Specify the offset in second from UTC as an integer.(e.g. '32400') This needs to be set along with location.",
 	).Default("0").Envar("SENDGRID_TIME_OFFSET").Int()
+	accumulatedMetrics = kingpin.Flag(
+		"sendgrid.accumulated-metrics",
+		"[Optional] Accumulated SendGrid Metrics by month, to calculate monthly email limit.",
+	).Default("False").Envar("SENDGRID_ACCUMULATED_METRICS").Bool()
+
 )
 
 func main() {

--- a/sendgrid.go
+++ b/sendgrid.go
@@ -42,19 +42,24 @@ type Statistics struct {
 	Stats []*Stat `json:"stats,omitempty"`
 }
 
-func collectByDate(time time.Time) ([]*Statistics, error) {
+func collectByDate(timeStart time.Time, timeEnd time.Time) ([]*Statistics, error) {
 	parsedURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
 
 	layout := "2006-01-02"
-	date := time.Format(layout)
+	dateStart := timeStart.Format(layout)
+	dateEnd := timeEnd.Format(layout)
 
 	query := url.Values{}
-	query.Set("start_date", date)
-	query.Set("end_date", date)
-	query.Set("aggregated_by", "day")
+	query.Set("start_date", dateStart)
+	query.Set("end_date", dateEnd)
+	if *accumulatedMetrics {
+		query.Set("aggregated_by", "month")
+	} else {
+		query.Set("aggregated_by", "day")
+	}
 	parsedURL.RawQuery = query.Encode()
 
 	req, err := http.NewRequest(http.MethodGet, parsedURL.String(), nil)


### PR DESCRIPTION
Accumulated SendGrid Metrics by month, to calculate monthly email limit