### PR TITLE
feat: add workflow to release helm chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
+
+jobs:
+  release:
+    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
+    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.5.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/charts/README.md
+++ b/charts/README.md
@@ -15,14 +15,12 @@ $ helm install -f examples/override.yaml sendgrid-stats-exporter ./
 
 ### Remote
 
-[helm-git](https://github.com/aslafy-z/helm-git) plugin is required.
-
 ```
-$ helm repo add sendgrid-stats-exporter 'git+https://github.com/chatwork/sendgrid-stats-exporter@charts?ref=0.0.8'
-$ helm install -f examples/override.yaml sendgrid-stats-exporter
+$ helm repo add sendgrid-stats-exporter 'https://chatwork.github.io/sendgrid-stats-exporter'
+$ helm install -f examples/override.yaml sendgrid-stats-exporter/sendgrid-stats-exporter
 ```
 
-### Test 
+### Test
 
 ```
 $ kubectl get svc


### PR DESCRIPTION
Hi @cw-sakamoto 👋 

First of all thanks a lot for this project, it is really useful 🤩 .

This little contribution allow us to release and download the helm chart in a more standard way compared to the usage of the helm plugin `helm-git` (also note that both method are compatible).

In order to the release process can work, we need to:

1.  Create a git branch named `gh-pages`
2. Enable the github pages on the repo
3. Point the github pages to the branch `gh-pages`

As mentionned [here](https://github.com/helm/chart-releaser-action#pre-requisites)

If you need more details, don't hesitate to ask

Cheers 