### PR TITLE
feat: delivery by category metric

### DIFF
--- a/collect.go
+++ b/collect.go
@@ -139,13 +139,16 @@ func collector(logger log.Logger) *Collector {
 }
 
 func (c *Collector) Collect(ch chan<- prometheus.Metric) {
-	var today time.Time
+	var today time.Time = time.Now()
 
 	if *location != "" && *timeOffset != 0 {
 		loc := time.FixedZone(*location, *timeOffset)
 		today = time.Now().In(loc)
-	} else {
-		today = time.Now()
+	} else if *location != "" {
+		loc, err := time.LoadLocation(*location)
+		if err == nil {
+			today = time.Now().In(loc)
+		}
 	}
 
 	queryDate := today

--- a/collect.go
+++ b/collect.go
@@ -31,103 +31,108 @@ type Collector struct {
 }
 
 func collector(logger log.Logger) *Collector {
+	var labels = []string{"user_name"}
+	if *byCategoryMetrics {
+		labels = append(labels, "category")
+	}
+
 	return &Collector{
 		logger: logger,
 
 		blocks: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "blocks"),
 			"blocks",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		bounceDrops: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "bounce_drops"),
 			"bounce_drops",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		bounces: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "bounces"),
 			"bounces",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		clicks: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "clicks"),
 			"clicks",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		deferred: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "deferred"),
 			"deferred",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		delivered: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "delivered"),
 			"delivered",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		invalidEmails: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "invalid_emails"),
 			"invalid_emails",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		opens: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "opens"),
 			"opens",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		processed: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "processed"),
 			"processed",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		requests: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "requests"),
 			"requests",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		spamReportDrops: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "spam_report_drops"),
 			"spam_report_drops",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		spamReports: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "spam_reports"),
 			"spam_reports",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		uniqueClicks: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "unique_clicks"),
 			"unique_clicks",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		uniqueOpens: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "unique_opens"),
 			"unique_opens",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		unsubscribeDrops: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "unsubscribe_drops"),
 			"unsubscribe_drops",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 		unsubscribes: prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", "unsubscribes"),
 			"unsubscribes",
-			[]string{"user_name"},
+			labels,
 			nil,
 		),
 	}
@@ -148,109 +153,231 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		queryDate = now.With(today).BeginningOfMonth()
 	}
 
-	statistics, err := collectByDate(queryDate, today)
-	if err != nil {
-		level.Error(c.logger).Log(err)
+	if !*byCategoryMetrics {
+		statistics, err := collectByDate(queryDate, today)
+		if err != nil {
+			level.Error(c.logger).Log(err)
+			return
+		}
 
-		return
-	}
+		for _, stats := range statistics[0].Stats {
+			ch <- prometheus.MustNewConstMetric(
+				c.blocks,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Blocks),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.bounceDrops,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.BounceDrops),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.bounces,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Bounces),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.clicks,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Clicks),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.deferred,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Deferred),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.delivered,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Delivered),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.invalidEmails,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.InvalidEmails),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.opens,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Opens),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.processed,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Processed),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.requests,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Requests),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.spamReportDrops,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.SpamReportDrops),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.spamReports,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.SpamReports),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.uniqueClicks,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.UniqueClicks),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.uniqueOpens,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.UniqueOpens),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.unsubscribeDrops,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.UnsubscribeDrops),
+				*sendGridUserName,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.unsubscribes,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Unsubscribes),
+				*sendGridUserName,
+			)
+		}
+	} else {
+		category_statistics, err := collectByCategory(today)
 
-	for _, stats := range statistics[0].Stats {
-		ch <- prometheus.MustNewConstMetric(
-			c.blocks,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Blocks),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.bounceDrops,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.BounceDrops),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.bounces,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Bounces),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.clicks,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Clicks),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.deferred,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Deferred),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.delivered,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Delivered),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.invalidEmails,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.InvalidEmails),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.opens,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Opens),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.processed,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Processed),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.requests,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Requests),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.spamReportDrops,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.SpamReportDrops),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.spamReports,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.SpamReports),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.uniqueClicks,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.UniqueClicks),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.uniqueOpens,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.UniqueOpens),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.unsubscribeDrops,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.UnsubscribeDrops),
-			*sendGridUserName,
-		)
-		ch <- prometheus.MustNewConstMetric(
-			c.unsubscribes,
-			prometheus.GaugeValue,
-			float64(stats.Metrics.Unsubscribes),
-			*sendGridUserName,
-		)
+		if err != nil {
+			level.Error(c.logger).Log(err)
+			return
+		}
+		for _, stats := range category_statistics.Stats {
+			ch <- prometheus.MustNewConstMetric(
+				c.blocks,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Blocks),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.bounceDrops,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.BounceDrops),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.bounces,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Bounces),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.clicks,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Clicks),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.deferred,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Deferred),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.delivered,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Delivered),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.invalidEmails,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.InvalidEmails),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.opens,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Opens),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.processed,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Processed),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.requests,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Requests),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.spamReportDrops,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.SpamReportDrops),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.spamReports,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.SpamReports),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.uniqueClicks,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.UniqueClicks),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.uniqueOpens,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.UniqueOpens),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.unsubscribeDrops,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.UnsubscribeDrops),
+				*sendGridUserName,
+				stats.Category,
+			)
+			ch <- prometheus.MustNewConstMetric(
+				c.unsubscribes,
+				prometheus.GaugeValue,
+				float64(stats.Metrics.Unsubscribes),
+				*sendGridUserName,
+				stats.Category,
+			)
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"github.com/prometheus/client_golang/prometheus/collectors"
 	"net/http"
 	"os"
 	"os/signal"
@@ -11,6 +10,7 @@ import (
 
 	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/promlog"
 	"github.com/prometheus/common/promlog/flag"
@@ -57,6 +57,10 @@ var (
 		"sendgrid.accumulated-metrics",
 		"[Optional] Accumulated SendGrid Metrics by month, to calculate monthly email limit.",
 	).Default("False").Envar("SENDGRID_ACCUMULATED_METRICS").Bool()
+	byCategoryMetrics = kingpin.Flag(
+		"sendgrid.by-category-metrics",
+		"[Optional] Collect SendGrid Metrics by category.",
+	).Default("False").Envar("SENDGRID_BY_CATEGORY_METRICS").Bool()
 )
 
 func main() {


### PR DESCRIPTION
This PR adds the metric `sendgrid_delivered_by_category`.

In particular, we need this to monitor if there is any category that is not being delivered. It might be helpful for others as well.

Any feedback is welcome.